### PR TITLE
add tests to improve test coverage

### DIFF
--- a/fd/diff_test.go
+++ b/fd/diff_test.go
@@ -119,3 +119,14 @@ func TestCentral(t *testing.T) {
 func TestCentralSecond(t *testing.T) {
 	testDerivative(t, Central2nd, 1e-3, testsSecond)
 }
+
+// TestDerivativeDefault checks that the derivative works when settings is set to nil.
+func TestDerivativeDefault(t *testing.T) {
+	tol := 1e-6
+	for i, test := range testsFirst {
+		ans := Derivative(test.f, test.loc, nil)
+		if math.Abs(test.ans-ans) > tol {
+			t.Errorf("Case %v: ans mismatch default: expected %v, found %v", i, test.ans, ans)
+		}
+	}
+}

--- a/fd/gradient_test.go
+++ b/fd/gradient_test.go
@@ -110,6 +110,7 @@ func TestGradient(t *testing.T) {
 		}
 		settings.Concurrent = true
 		settings.OriginKnown = false
+		settings.Workers = 1000
 		Gradient(r.F, x, settings, gradient)
 		if !floats.EqualApprox(gradient, trueGradient, test.tol) {
 			t.Errorf("Case %v: gradient mismatch with unknown origin in parallel. Want: %v, Got: %v.", i, trueGradient, gradient)
@@ -128,5 +129,35 @@ func TestGradient(t *testing.T) {
 			t.Errorf("Case %v: gradient mismatch with known origin in parallel. Want: %v, Got: %v.", i, trueGradient, gradient)
 		}
 
+		// With default settings
+		for i := range gradient {
+			gradient[i] = rand.Float64()
+		}
+		settings = nil
+		Gradient(r.F, x, settings, gradient)
+		if !floats.EqualApprox(gradient, trueGradient, test.tol) {
+			t.Errorf("Case %v: gradient mismatch with default settings. Want: %v, Got: %v.", i, trueGradient, gradient)
+		}
+
+	}
+}
+
+func Panics(fun func()) (b bool) {
+	defer func() {
+		err := recover()
+		if err != nil {
+			b = true
+		}
+	}()
+	fun()
+	return
+}
+
+func TestGradientPanics(t *testing.T) {
+	// Test that it panics
+	if !Panics(func() {
+		Gradient(func(x []float64) float64 { return x[0] * x[0] }, []float64{0.0, 0.0}, nil, []float64{0.0})
+	}) {
+		t.Errorf("Gradient did not panic with length mismatch")
 	}
 }


### PR DESCRIPTION
Added tests which cover cases with default settings, the panic in
Gradient, and one where more workers are asked for than can be used.
Test coverage is now 100%.
