### PR TITLE
add conditional for test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
  - go build -v ./...
  - go test -v ./...
  - diff <(gofmt -d .) <("")
- - bash test-coverage.sh
+ - if [[ $TRAVIS_SECURE_ENV_VARS = "true" ]]; then bash test-coverage.sh; fi
 
 after_failure: failure
 


### PR DESCRIPTION
travis-ci only has secure variables available when a pull is from a
branch of gonum.  This conditional makes it so that coverage is only
calculated when the coveralls api key is available.
