### PR TITLE
Change the default formula to Forward in Derivative and Gradient

### DIFF
--- a/fd/diff.go
+++ b/fd/diff.go
@@ -105,12 +105,14 @@ func Derivative(f func(float64) float64, x float64, settings *Settings) float64 
 }
 
 // Gradient estimates the gradient of the multivariate function f at the
-// location x. The result is stored in-place into dst if dst is not nil,
-// otherwise a new slice will be allocated and returned. Finite difference
-// kernel and other options are specified by settings. If settings is nil,
-// default settings will be used.
-// Gradient panics if the length of dst and x is not equal, or if the
-// derivative order of the formula is not 1.
+// location x. If dst is not nil, the result will be stored in-place into dst
+// and returned, otherwise a new slice will be allocated first. Finite
+// difference kernel and other options are specified by settings. If settings is
+// nil, the gradient will be estimated using the Forward formula and a default
+// step size.
+//
+// Gradient panics if the length of dst and x is not equal, or if the derivative
+// order of the formula is not 1.
 func Gradient(dst []float64, f func([]float64) float64, x []float64, settings *Settings) []float64 {
 	if dst == nil {
 		dst = make([]float64, len(x))

--- a/fd/diff.go
+++ b/fd/diff.go
@@ -38,7 +38,7 @@ func (f Formula) isZero() bool {
 type Settings struct {
 	// Formula is the finite difference formula used
 	// for approximating the derivative.
-	// Zero value will default to the Central formula.
+	// Zero value indicates a default formula.
 	Formula Formula
 	// Step is the distance between points of the stencil.
 	// If equal to 0, formula's default step will be used.
@@ -53,14 +53,14 @@ type Settings struct {
 // Derivative estimates the derivative of the function f at the given location.
 // The finite difference formula, the step size, and other options are
 // specified by settings. If settings is nil, the first derivative will be
-// estimated using the Central formula and a default step size.
+// estimated using the Forward formula and a default step size.
 func Derivative(f func(float64) float64, x float64, settings *Settings) float64 {
 	if settings == nil {
 		settings = &Settings{}
 	}
 	formula := settings.Formula
 	if formula.isZero() {
-		formula = Central
+		formula = Forward
 	}
 	if formula.Derivative == 0 || formula.Stencil == nil || formula.Step == 0 {
 		panic("fd: bad formula")
@@ -124,7 +124,7 @@ func Gradient(dst []float64, f func([]float64) float64, x []float64, settings *S
 
 	formula := settings.Formula
 	if formula.isZero() {
-		formula = Central
+		formula = Forward
 	}
 	if formula.Derivative == 0 || formula.Stencil == nil || formula.Step == 0 {
 		panic("fd: bad formula")

--- a/fd/example_test.go
+++ b/fd/example_test.go
@@ -21,19 +21,18 @@ func ExampleDerivative() {
 	// with a custom step size.
 	df := fd.Derivative(f, 0, &fd.Settings{
 		Formula: fd.Forward,
-		Step:    1e-8,
+		Step:    1e-3,
 	})
 	fmt.Println("f'(0) ≈", df)
 
 	f = func(x float64) float64 {
 		return math.Pow(math.Cos(x), 3)
 	}
-	// Compute the second derivative of f at 0 using the centered
-	// approximation, a custom step size, concurrent evaluation, and a known
-	// function value at x.
+	// Compute the second derivative of f at 0 using
+	// the centered approximation, concurrent evaluation,
+	// and a known function value at x.
 	df = fd.Derivative(f, 0, &fd.Settings{
 		Formula:     fd.Central2nd,
-		Step:        1e-4,
 		Concurrent:  true,
 		OriginKnown: true,
 		OriginValue: f(0),
@@ -41,7 +40,7 @@ func ExampleDerivative() {
 	fmt.Println("f''(0) ≈", df)
 
 	// Output:
-	// f'(0) ≈ 0.999999999994
 	// f'(0) ≈ 1
+	// f'(0) ≈ 0.9999998333333416
 	// f''(0) ≈ -2.999999981767587
 }


### PR DESCRIPTION
PTAL @btracey 

Another data point in favor of the change: Not sure how representative this test is but running the optimization program below gives the following output:
With Central:
```
      174    3m28.81848401s        179       1.421326215861356        176    8.09334081234662e-07
./minsurf  1185.38s user 0.42s system 567% cpu 3:28.82 total
```
With Forward:
```
      153   1m30.488590397s        156      1.4213262196139937        155    7.66053886991358e-07
./minsurf  522.19s user 0.15s system 577% cpu 1:30.49 total
```

```go
package main

func main() {
        f := functions.NewMinimalSurface(100, 100)
        fdgrad := func(g, x []float64) {
                fd.Gradient(g, f.Func, x, &fd.Settings{
                        Formula:    fd.Forward,
                        Concurrent: true,
                })  
        }   
        p := optimize.Problem{
                Func: f.Func,
                Grad: fdgrad,
        }   
        s := optimize.DefaultSettings()
        s.Recorder = optimize.NewPrinter()
        _, err := optimize.Local(p, f.InitX(), s, &optimize.LBFGS{})
        if err != nil {
                log.Fatal(err)
        }   
}
```

Closes #30.